### PR TITLE
Update ananas analytics website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ even a command-line client available.
 
 # ananas analytics
 
-[Ananas Analytics](https://ananasanalytics.com) is a platform that can be used
+[Ananas Analytics](https://github.com/ananas-analytics/ananas-desktop) is a platform that can be used
 for quick data visualization using either files or cloud-based database engines
 as its data store. For scalability, the execution can be ran inside e.g. Apache
 Spark. But by default, the execution itself always takes place on the desktop.


### PR DESCRIPTION
The original link (https://ananasanalytics.com) no longer seems to work.